### PR TITLE
:bug: fix: use correct path separators for unique_prefix depending on OS

### DIFF
--- a/lua/cokeline/buffers.lua
+++ b/lua/cokeline/buffers.lua
@@ -60,7 +60,7 @@ local function get_unique_prefix(filename)
     other_filenames
   )))
 
-  local path_separator = '/'
+  local path_separator = fn.has("win32") and '\\' or '/'
 
   while index <= #filename do
     if filename:sub(index, index) == path_separator then


### PR DESCRIPTION
unique_prefix was broken on windows, this fixes it.

Also, should unique_prefix only be returned when the number of buffers > 1? 

Great plugin btw. :)