### PR TITLE
:bug: fix: `unique_prefix` on windows

### DIFF
--- a/lua/cokeline/buffers.lua
+++ b/lua/cokeline/buffers.lua
@@ -35,10 +35,14 @@ local M = {}
 local function get_unique_prefix(filename)
   -- Taken from github.com/famiu/feline.nvim
 
-  filename = filename:gsub('\\', '/')
+  if fn.has('win32') == 1 then
+    filename = filename:gsub('/', '\\')
+  end
 
   local listed_buffers = fn.getbufinfo({buflisted = 1})
-  local filenames = map(function(b) return b.name:gsub('\\', '/') end, listed_buffers)
+  local filenames = map(function(b)
+    return (fn.has('win32') == 0) and b.name or b.name:gsub('/', '\\')
+  end, listed_buffers)
   local other_filenames = filter(
     function(f) return filename ~= f end,
     filenames
@@ -63,7 +67,7 @@ local function get_unique_prefix(filename)
     other_filenames
   )))
 
-  local path_separator = '/'
+  local path_separator = (fn.has('win32') == 0) and '/' or '\\'
 
   while index <= #filename do
     if filename:sub(index, index) == path_separator then

--- a/lua/cokeline/buffers.lua
+++ b/lua/cokeline/buffers.lua
@@ -35,8 +35,10 @@ local M = {}
 local function get_unique_prefix(filename)
   -- Taken from github.com/famiu/feline.nvim
 
+  filename = filename:gsub('\\', '/')
+
   local listed_buffers = fn.getbufinfo({buflisted = 1})
-  local filenames = map(function(b) return b.name end, listed_buffers)
+  local filenames = map(function(b) return b.name:gsub('\\', '/') end, listed_buffers)
   local other_filenames = filter(
     function(f) return filename ~= f end,
     filenames
@@ -61,7 +63,7 @@ local function get_unique_prefix(filename)
     other_filenames
   )))
 
-  local path_separator = (fn.has('win32') == 0) and '/' or '\\'
+  local path_separator = '/'
 
   while index <= #filename do
     if filename:sub(index, index) == path_separator then


### PR DESCRIPTION
`vim.fn.getbufinfo({ buflisted = 1 })` is not consistent on windows. Often it provides path with mixed path separators. Since we are just displaying the file name/path, it is better to convert windows path to linux path. 

Consequently, `local path_separator = (fn.has('win32') == 0) and '/' or '\\'` can be reverted to `local path_separator = '/'`.

Now, get_unique_prefix works as intended. I hope this doesn't break anything in linux 😅.

